### PR TITLE
Changed SQL for UKBMS Site Species list reports

### DIFF
--- a/reports/projects/ukbms/ukbms_site_species.xml
+++ b/reports/projects/ukbms/ukbms_site_species.xml
@@ -5,7 +5,7 @@
     from cache_samples_functional csf
     join cache_occurrences_functional cof on cof.sample_id = csf.id
     join locations l on l.id = csf.location_id
-    join cache_taxa_taxon_lists cttl on cttl.taxon_meaning_id = cof.taxon_meaning_id
+    join cache_taxa_taxon_lists cttl on cttl.preferred_taxa_taxon_list_id = cof.preferred_taxa_taxon_list_id
     where csf.website_id=27
     and (l.parent_id=#location_id# or l.id=#location_id#)
     and cof.taxon_group_id = 104


### PR DESCRIPTION
Replaced taxon_meaning_id with preferred_taxa_taxon_list_id
as key to join cache_taxa_taxon_lists to avoid problems with
taxa where taxon_meaning_id is used over several lists,
e.g. Wood White.