### PR TITLE
Added 17966 to line 18

### DIFF
--- a/reports/projects/wildsheffield/my_sites_lookup.xml
+++ b/reports/projects/wildsheffield/my_sites_lookup.xml
@@ -15,7 +15,7 @@
       #joins#
       WHERE l.deleted=false
       AND #website_filter#
-      AND l.location_type_id IN (1371, 14689, 17965)
+      AND l.location_type_id IN (1371, 14689, 17965, 17966)
       AND (
         -- include sites the user created
         (l.created_by_id=#user_id# AND l.location_type_id=1371)


### PR DESCRIPTION
On the live site doesn't seem that project site are showing up. Test:  https://record.wildsheffield.com/record/casual-record and search for 'Wadsle..' should bring up location 'Wadsley and Loxley Common'. Have suggested an edit that should make it work if I've understood the logic.